### PR TITLE
Add table container just around <table> element

### DIFF
--- a/src/dioxus/table.rs
+++ b/src/dioxus/table.rs
@@ -186,21 +186,24 @@ pub fn Table(props: TableProps) -> Element {
                     }
                 }
             }
-            table {
-                class: "{classes.table}",
-                TableHeader {
-                    columns: columns.clone(),
-                    sort_column: sort_column,
-                    sort_order: sort_order,
-                    on_sort_column: on_sort_column,
-                    classes: classes.clone(),
-                }
-                TableBody {
-                    columns: columns.clone(),
-                    rows: page_rows.to_vec(),
-                    loading: loading,
-                    classes: classes.clone(),
-                    texts: texts.clone(),
+            div {
+                class: "{classes.table_container}",
+                table {
+                    class: "{classes.table}",
+                    TableHeader {
+                        columns: columns.clone(),
+                        sort_column: sort_column,
+                        sort_order: sort_order,
+                        on_sort_column: on_sort_column,
+                        classes: classes.clone(),
+                    }
+                    TableBody {
+                        columns: columns.clone(),
+                        rows: page_rows.to_vec(),
+                        loading: loading,
+                        classes: classes.clone(),
+                        texts: texts.clone(),
+                    }
                 }
             }
             {pagination_controls}

--- a/src/dioxus/types.rs
+++ b/src/dioxus/types.rs
@@ -74,6 +74,9 @@ pub struct TableClasses {
     /// Wrapper around the entire table.
     pub container: &'static str,
 
+    /// Wrapper around just the <table> element.
+    pub table_container: &'static str,
+
     /// Class for the `<table>` element.
     pub table: &'static str,
 
@@ -112,6 +115,7 @@ impl Default for TableClasses {
     fn default() -> Self {
         Self {
             container: "table-container",
+            table_container: "table-el-container",
             table: "table",
             thead: "thead",
             tbody: "tbody",

--- a/src/yew/table.rs
+++ b/src/yew/table.rs
@@ -205,21 +205,23 @@ pub fn table(props: &TableProps) -> Html {
                 } else {
                     html! {}
                 } }
-            <table class={classes.table} style={*styles.get("table").unwrap_or(&"")} role="table">
-                <TableHeader
-                    columns={columns.clone()}
-                    {sort_column}
-                    {sort_order}
-                    {on_sort_column}
-                    classes={classes.clone()}
-                />
-                <TableBody
-                    columns={columns.clone()}
-                    rows={page_rows.to_vec()}
-                    loading={loading}
-                    classes={classes.clone()}
-                />
-            </table>
+            <div class={classes.table_container}>
+                <table class={classes.table} style={*styles.get("table").unwrap_or(&"")} role="table">
+                    <TableHeader
+                        columns={columns.clone()}
+                        {sort_column}
+                        {sort_order}
+                        {on_sort_column}
+                        classes={classes.clone()}
+                    />
+                    <TableBody
+                        columns={columns.clone()}
+                        rows={page_rows.to_vec()}
+                        loading={loading}
+                        classes={classes.clone()}
+                    />
+                </table>
+            </div>
             { if *paginate {
                     html! {
                         <PaginationControls {page} {total_pages} />

--- a/src/yew/types.rs
+++ b/src/yew/types.rs
@@ -51,6 +51,10 @@ pub struct TableClasses {
     #[prop_or("table-container")]
     pub container: &'static str,
 
+    /// Class name for the the container just around <table> element
+    #[prop_or("table-container")]
+    pub table_container: &'static str,
+
     /// Class name for the table element.
     #[prop_or("table")]
     pub table: &'static str,
@@ -100,6 +104,7 @@ impl Default for TableClasses {
     fn default() -> Self {
         Self {
             container: "table-container",
+            table_container: "table-el-container",
             table: "table",
             thead: "thead",
             tbody: "tbody",


### PR DESCRIPTION
This is required by i.e. Bulma CSS in order to get horizontal table scrolling:

```html
<div class="table-container">
  <table class="table">
    ...
  </table>
</div>
```

Container must be just around <table> element to scroll just the table, not pagination, input box, etc.

In turn existing property `container` is not usable for this.