### PR TITLE
Fix: support non-Wasm targets for Dioxus builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["/assets", "/examples"]
 yew = { version = "0.21.0", default-features = false, optional = true }
 dioxus = { version = "0.7.1", optional = true }
 leptos = { version = "0.7.7", optional = true }
-web-sys = { version = "0.3.77", features = ["Window", "UrlSearchParams", "Url"]}
+web-sys = { version = "0.3.77", features = ["Window", "UrlSearchParams", "Url", "Location"]}
 gloo-timers = { version = "0.3.0", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = ["/assets", "/examples"]
 yew = { version = "0.21.0", default-features = false, optional = true }
 dioxus = { version = "0.7.1", optional = true }
 leptos = { version = "0.7.7", optional = true }
-web-sys = { version = "0.3.77", features = ["Window", "UrlSearchParams", "Url", "Location"]}
+web-sys = { version = "0.3.77", features = ["Window", "UrlSearchParams", "Url", "Location", "History"]}
 gloo-timers = { version = "0.3.0", optional = true }
 
 [features]

--- a/src/dioxus/table.rs
+++ b/src/dioxus/table.rs
@@ -85,7 +85,7 @@ pub fn Table(props: TableProps) -> Element {
     let mut sort_order = use_signal(SortOrder::default);
     let mut search_query = use_signal(String::new);
 
-    #[cfg(target_arch = "wasm")]
+    #[cfg(target_family = "wasm")]
     use_effect(move || {
         let window = web_sys::window().unwrap();
         let location = window.location();
@@ -96,7 +96,7 @@ pub fn Table(props: TableProps) -> Element {
         }
     });
 
-    #[cfg(target_arch = "wasm")]
+    #[cfg(target_family = "wasm")]
     let update_search_param = move |query: &str| {
         let window = web_sys::window().unwrap();
         let href = window.location().href().unwrap();

--- a/src/dioxus/table.rs
+++ b/src/dioxus/table.rs
@@ -184,7 +184,7 @@ pub fn Table(props: TableProps) -> Element {
                         let val = e.value();
                         search_query.set(val.clone());
                         page.set(0);
-                        #[cfg(target_arch = "wasm")]
+                        #[cfg(target_family = "wasm")]
                         update_search_param(&val);
                     }
                 }

--- a/src/dioxus/table.rs
+++ b/src/dioxus/table.rs
@@ -85,6 +85,7 @@ pub fn Table(props: TableProps) -> Element {
     let mut sort_order = use_signal(SortOrder::default);
     let mut search_query = use_signal(String::new);
 
+    #[cfg(target_arch = "wasm")]
     use_effect(move || {
         let window = web_sys::window().unwrap();
         let location = window.location();
@@ -95,6 +96,7 @@ pub fn Table(props: TableProps) -> Element {
         }
     });
 
+    #[cfg(target_arch = "wasm")]
     let update_search_param = move |query: &str| {
         let window = web_sys::window().unwrap();
         let href = window.location().href().unwrap();
@@ -182,6 +184,7 @@ pub fn Table(props: TableProps) -> Element {
                         let val = e.value();
                         search_query.set(val.clone());
                         page.set(0);
+                        #[cfg(target_arch = "wasm")]
                         update_search_param(&val);
                     }
                 }


### PR DESCRIPTION
URL handling to store the current search parameter only works on `wasm` targets, hence it has been disabled for non-Wasm builds. The state is maintained inside the component.
Fixes #11 