### PR TITLE
Added classes property to the pagination controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,12 +102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
-name = "anymap2"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
-
-[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,21 +166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,12 +194,6 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "boolinator"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bstr"
@@ -900,13 +864,13 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "gloo-timers 0.3.0",
+ "gloo-timers",
  "js-sys",
  "lazy-js-bundle",
  "rustc-hash 2.1.1",
  "send_wrapper",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "tracing",
  "wasm-bindgen",
@@ -1238,12 +1202,6 @@ dependencies = [
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gix"
@@ -2077,53 +2035,21 @@ dependencies = [
 
 [[package]]
 name = "gloo"
-version = "0.8.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28999cda5ef6916ffd33fb4a7b87e1de633c47c0dc6d97905fee1cdaa142b94d"
+checksum = "d15282ece24eaf4bd338d73ef580c6714c8615155c4190c781290ee3fa0fd372"
 dependencies = [
- "gloo-console 0.2.3",
- "gloo-dialogs 0.1.1",
- "gloo-events 0.1.2",
- "gloo-file 0.2.3",
- "gloo-history 0.1.5",
- "gloo-net 0.3.1",
- "gloo-render 0.1.1",
- "gloo-storage 0.2.2",
- "gloo-timers 0.2.6",
- "gloo-utils 0.1.7",
- "gloo-worker 0.2.1",
-]
-
-[[package]]
-name = "gloo"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd35526c28cc55c1db77aed6296de58677dbab863b118483a27845631d870249"
-dependencies = [
- "gloo-console 0.3.0",
- "gloo-dialogs 0.2.0",
- "gloo-events 0.2.0",
- "gloo-file 0.3.0",
- "gloo-history 0.2.2",
- "gloo-net 0.4.0",
- "gloo-render 0.2.0",
- "gloo-storage 0.3.0",
- "gloo-timers 0.3.0",
- "gloo-utils 0.2.0",
- "gloo-worker 0.4.0",
-]
-
-[[package]]
-name = "gloo-console"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b7ce3c05debe147233596904981848862b068862e9ec3e34be446077190d3f"
-dependencies = [
- "gloo-utils 0.1.7",
- "js-sys",
- "serde",
- "wasm-bindgen",
- "web-sys",
+ "gloo-console",
+ "gloo-dialogs",
+ "gloo-events",
+ "gloo-file",
+ "gloo-history",
+ "gloo-net 0.5.0",
+ "gloo-render",
+ "gloo-storage",
+ "gloo-timers",
+ "gloo-utils",
+ "gloo-worker",
 ]
 
 [[package]]
@@ -2132,19 +2058,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a17868f56b4a24f677b17c8cb69958385102fa879418052d60b50bc1727e261"
 dependencies = [
- "gloo-utils 0.2.0",
+ "gloo-utils",
  "js-sys",
  "serde",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-dialogs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67062364ac72d27f08445a46cab428188e2e224ec9e37efdba48ae8c289002e6"
-dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
@@ -2154,16 +2070,6 @@ name = "gloo-dialogs"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4748e10122b01435750ff530095b1217cf6546173459448b83913ebe7815df"
-dependencies = [
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-events"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b107f8abed8105e4182de63845afcc7b69c098b7852a813ea7462a320992fc"
 dependencies = [
  "wasm-bindgen",
  "web-sys",
@@ -2181,40 +2087,12 @@ dependencies = [
 
 [[package]]
 name = "gloo-file"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d5564e570a38b43d78bdc063374a0c3098c4f0d64005b12f9bbe87e869b6d7"
-dependencies = [
- "gloo-events 0.1.2",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-file"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97563d71863fb2824b2e974e754a81d19c4a7ec47b09ced8a0e6656b6d54bd1f"
 dependencies = [
- "gloo-events 0.2.0",
+ "gloo-events",
  "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-history"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85725d90bf0ed47063b3930ef28e863658a7905989e9929a8708aab74a1d5e7f"
-dependencies = [
- "gloo-events 0.1.2",
- "gloo-utils 0.1.7",
- "serde",
- "serde-wasm-bindgen 0.5.0",
- "serde_urlencoded",
- "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -2226,10 +2104,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "903f432be5ba34427eac5e16048ef65604a82061fe93789f2212afc73d8617d6"
 dependencies = [
  "getrandom 0.2.15",
- "gloo-events 0.2.0",
- "gloo-utils 0.2.0",
+ "gloo-events",
+ "gloo-utils",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_urlencoded",
  "thiserror 1.0.69",
  "wasm-bindgen",
@@ -2238,35 +2116,14 @@ dependencies = [
 
 [[package]]
 name = "gloo-net"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66b4e3c7d9ed8d315fd6b97c8b1f74a7c6ecbbc2320e65ae7ed38b7068cc620"
+checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
 dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
- "gloo-utils 0.1.7",
- "http 0.2.12",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-net"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac9e8288ae2c632fa9f8657ac70bfe38a1530f345282d7ba66a1f70b72b7dc4"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils 0.2.0",
+ "gloo-utils",
  "http 0.2.12",
  "js-sys",
  "pin-project",
@@ -2287,7 +2144,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
- "gloo-utils 0.2.0",
+ "gloo-utils",
  "http 1.2.0",
  "js-sys",
  "pin-project",
@@ -2296,16 +2153,6 @@ dependencies = [
  "thiserror 1.0.69",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-render"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd9306aef67cfd4449823aadcd14e3958e0800aa2183955a309112a84ec7764"
-dependencies = [
- "wasm-bindgen",
  "web-sys",
 ]
 
@@ -2321,42 +2168,17 @@ dependencies = [
 
 [[package]]
 name = "gloo-storage"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6ab60bf5dbfd6f0ed1f7843da31b41010515c745735c970e821945ca91e480"
-dependencies = [
- "gloo-utils 0.1.7",
- "js-sys",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-storage"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc8031e8c92758af912f9bc08fbbadd3c6f3cfcbf6b64cdf3d6a81f0139277a"
 dependencies = [
- "gloo-utils 0.2.0",
+ "gloo-utils",
  "js-sys",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2369,19 +2191,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2399,30 +2208,13 @@ dependencies = [
 
 [[package]]
 name = "gloo-worker"
-version = "0.2.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13471584da78061a28306d1359dd0178d8d6fc1c7c80e5e35d27260346e0516a"
-dependencies = [
- "anymap2",
- "bincode",
- "gloo-console 0.2.3",
- "gloo-utils 0.1.7",
- "js-sys",
- "serde",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-worker"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76495d3dd87de51da268fa3a593da118ab43eb7f8809e17eb38d3319b424e400"
+checksum = "085f262d7604911c8150162529cefab3782e91adb20202e8658f7275d2aefe5d"
 dependencies = [
  "bincode",
  "futures",
- "gloo-utils 0.2.0",
+ "gloo-utils",
  "gloo-worker-macros",
  "js-sys",
  "pinned",
@@ -2478,6 +2270,12 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heapless"
@@ -2717,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "implicit-clone"
-version = "0.4.9"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a9aa791c7b5a71b636b7a68207fdebf171ddfc593d9c8506ec4cbc527b6a84"
+checksum = "1689b939ee35e3a075b0834b5672efd43aec8a6e81a1c6002b76a5ca2f211ae0"
 dependencies = [
  "implicit-clone-derive",
  "indexmap",
@@ -2737,12 +2535,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3276,15 +3074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "oco_ref"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,23 +3319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prokio"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b55e106e5791fa5a13abd13c85d6127312e8e09098059ca2bc9b03ca4cf488"
-dependencies = [
- "futures",
- "gloo 0.8.1",
- "num_cpus",
- "once_cell",
- "pin-project",
- "pinned",
- "tokio",
- "tokio-stream",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,12 +3508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3823,17 +3589,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4148,7 +3903,7 @@ version = "0.0.4"
 dependencies = [
  "bump2version",
  "dioxus",
- "gloo-timers 0.3.0",
+ "gloo-timers",
  "leptos",
  "log",
  "maplit",
@@ -4289,12 +4044,23 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "backtrace",
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4306,6 +4072,23 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokise"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf97738ce15b9e9cc1671ea29b0f6c56538719e1a092d19cc2134bf144e40e"
+dependencies = [
+ "futures",
+ "gloo",
+ "num_cpus",
+ "once_cell",
+ "pin-project",
+ "pinned",
+ "tokio",
+ "tokio-stream",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -4930,22 +4713,22 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yew"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1a03f255c70c7aa3e9c62e15292f142ede0564123543c1cc0c7a4f31660cac"
+checksum = "3346273ed61b636f5d84e6c696d40f380045b5565b36c5c47f8fc634b8bf5be6"
 dependencies = [
  "console_error_panic_hook",
  "futures",
- "gloo 0.10.0",
+ "gloo",
  "implicit-clone",
  "indexmap",
  "js-sys",
- "prokio",
  "rustversion",
  "serde",
  "slab",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
+ "tokise",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4955,16 +4738,16 @@ dependencies = [
 
 [[package]]
 name = "yew-macro"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fd8ca5166d69e59f796500a2ce432ff751edecbbb308ca59fd3fe4d0343de2"
+checksum = "479e94d645dde3749e81d488c1d32987509dd3b8c31650fcf6e3af1f370e913b"
 dependencies = [
- "boolinator",
  "once_cell",
  "prettyplease",
  "proc-macro-error",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn 2.0.108",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["/assets", "/examples"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-yew = { version = "0.21.0", default-features = false, optional = true }
+yew = { version = "0.22.0", default-features = false, optional = true }
 dioxus = { version = "0.7.1", optional = true }
 leptos = { version = "0.7.7", optional = true }
 web-sys = { version = "0.3.77", features = ["Window", "UrlSearchParams", "Url"]}

--- a/bench/yew/Cargo.toml
+++ b/bench/yew/Cargo.toml
@@ -11,8 +11,8 @@ table-rs = { path = "../../", features = ["yew"] }
 console_error_panic_hook = "0.1.7"
 log = "0.4.22"
 wasm-logger = "0.2.0"
-yew = { version = "0.21.0", features = ["csr"], default-features = false }
-yew-router = { version = "0.18.0", default-features = false }
+yew = { version = "0.22.0", features = ["csr"], default-features = false }
+yew-router = { version = "0.19.0", default-features = false }
 maplit = "1.0.2"
 web-sys = { version = "0.3.77", features = ["Window", "Performance"] }
 

--- a/examples/yew/Cargo.lock
+++ b/examples/yew/Cargo.lock
@@ -3,46 +3,10 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "anymap2"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "bincode"
@@ -52,12 +16,6 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "boolinator"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "bumpalo"
@@ -70,15 +28,6 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
-
-[[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cfg-if"
@@ -161,7 +110,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -208,60 +157,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
 name = "gloo"
-version = "0.8.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28999cda5ef6916ffd33fb4a7b87e1de633c47c0dc6d97905fee1cdaa142b94d"
+checksum = "d15282ece24eaf4bd338d73ef580c6714c8615155c4190c781290ee3fa0fd372"
 dependencies = [
- "gloo-console 0.2.3",
- "gloo-dialogs 0.1.1",
- "gloo-events 0.1.2",
- "gloo-file 0.2.3",
- "gloo-history 0.1.5",
- "gloo-net 0.3.1",
- "gloo-render 0.1.1",
- "gloo-storage 0.2.2",
- "gloo-timers 0.2.6",
- "gloo-utils 0.1.7",
- "gloo-worker 0.2.1",
-]
-
-[[package]]
-name = "gloo"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd35526c28cc55c1db77aed6296de58677dbab863b118483a27845631d870249"
-dependencies = [
- "gloo-console 0.3.0",
- "gloo-dialogs 0.2.0",
- "gloo-events 0.2.0",
- "gloo-file 0.3.0",
- "gloo-history 0.2.2",
- "gloo-net 0.4.0",
- "gloo-render 0.2.0",
- "gloo-storage 0.3.0",
- "gloo-timers 0.3.0",
- "gloo-utils 0.2.0",
- "gloo-worker 0.4.0",
-]
-
-[[package]]
-name = "gloo-console"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b7ce3c05debe147233596904981848862b068862e9ec3e34be446077190d3f"
-dependencies = [
- "gloo-utils 0.1.7",
- "js-sys",
- "serde",
- "wasm-bindgen",
- "web-sys",
+ "gloo-console",
+ "gloo-dialogs",
+ "gloo-events",
+ "gloo-file",
+ "gloo-history",
+ "gloo-net",
+ "gloo-render",
+ "gloo-storage",
+ "gloo-timers",
+ "gloo-utils",
+ "gloo-worker",
 ]
 
 [[package]]
@@ -270,19 +181,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a17868f56b4a24f677b17c8cb69958385102fa879418052d60b50bc1727e261"
 dependencies = [
- "gloo-utils 0.2.0",
+ "gloo-utils",
  "js-sys",
  "serde",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-dialogs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67062364ac72d27f08445a46cab428188e2e224ec9e37efdba48ae8c289002e6"
-dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
@@ -292,16 +193,6 @@ name = "gloo-dialogs"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4748e10122b01435750ff530095b1217cf6546173459448b83913ebe7815df"
-dependencies = [
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-events"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b107f8abed8105e4182de63845afcc7b69c098b7852a813ea7462a320992fc"
 dependencies = [
  "wasm-bindgen",
  "web-sys",
@@ -319,41 +210,13 @@ dependencies = [
 
 [[package]]
 name = "gloo-file"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d5564e570a38b43d78bdc063374a0c3098c4f0d64005b12f9bbe87e869b6d7"
-dependencies = [
- "gloo-events 0.1.2",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-file"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97563d71863fb2824b2e974e754a81d19c4a7ec47b09ced8a0e6656b6d54bd1f"
 dependencies = [
  "futures-channel",
- "gloo-events 0.2.0",
+ "gloo-events",
  "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-history"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85725d90bf0ed47063b3930ef28e863658a7905989e9929a8708aab74a1d5e7f"
-dependencies = [
- "gloo-events 0.1.2",
- "gloo-utils 0.1.7",
- "serde",
- "serde-wasm-bindgen 0.5.0",
- "serde_urlencoded",
- "thiserror",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -365,65 +228,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "903f432be5ba34427eac5e16048ef65604a82061fe93789f2212afc73d8617d6"
 dependencies = [
  "getrandom",
- "gloo-events 0.2.0",
- "gloo-utils 0.2.0",
+ "gloo-events",
+ "gloo-utils",
  "serde",
- "serde-wasm-bindgen 0.6.3",
+ "serde-wasm-bindgen",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 1.0.56",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "gloo-net"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66b4e3c7d9ed8d315fd6b97c8b1f74a7c6ecbbc2320e65ae7ed38b7068cc620"
+checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
 dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
- "gloo-utils 0.1.7",
+ "gloo-utils",
  "http",
  "js-sys",
  "pin-project",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.56",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-net"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac9e8288ae2c632fa9f8657ac70bfe38a1530f345282d7ba66a1f70b72b7dc4"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils 0.2.0",
- "http",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-render"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd9306aef67cfd4449823aadcd14e3958e0800aa2183955a309112a84ec7764"
-dependencies = [
- "wasm-bindgen",
  "web-sys",
 ]
 
@@ -439,42 +271,17 @@ dependencies = [
 
 [[package]]
 name = "gloo-storage"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6ab60bf5dbfd6f0ed1f7843da31b41010515c745735c970e821945ca91e480"
-dependencies = [
- "gloo-utils 0.1.7",
- "js-sys",
- "serde",
- "serde_json",
- "thiserror",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-storage"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbc8031e8c92758af912f9bc08fbbadd3c6f3cfcbf6b64cdf3d6a81f0139277a"
 dependencies = [
- "gloo-utils 0.2.0",
+ "gloo-utils",
  "js-sys",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.56",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -487,19 +294,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -517,35 +311,18 @@ dependencies = [
 
 [[package]]
 name = "gloo-worker"
-version = "0.2.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13471584da78061a28306d1359dd0178d8d6fc1c7c80e5e35d27260346e0516a"
-dependencies = [
- "anymap2",
- "bincode",
- "gloo-console 0.2.3",
- "gloo-utils 0.1.7",
- "js-sys",
- "serde",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-worker"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76495d3dd87de51da268fa3a593da118ab43eb7f8809e17eb38d3319b424e400"
+checksum = "085f262d7604911c8150162529cefab3782e91adb20202e8658f7275d2aefe5d"
 dependencies = [
  "bincode",
  "futures",
- "gloo-utils 0.2.0",
+ "gloo-utils",
  "gloo-worker-macros",
  "js-sys",
  "pinned",
  "serde",
- "thiserror",
+ "thiserror 1.0.56",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -560,14 +337,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hermit-abi"
@@ -588,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "implicit-clone"
-version = "0.4.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc06a255cbf402a52ae399c05a518c68c569c916ea11423620111df576b9b9bb"
+checksum = "1689b939ee35e3a075b0834b5672efd43aec8a6e81a1c6002b76a5ca2f211ae0"
 dependencies = [
  "implicit-clone-derive",
  "indexmap",
@@ -603,14 +380,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9311685eb9a34808bbb0608ad2fcab9ae216266beca5848613e95553ac914e3b"
 dependencies = [
  "quote",
- "syn 2.0.48",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -657,15 +434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
-dependencies = [
- "adler",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,15 +441,6 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -713,7 +472,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -736,7 +495,7 @@ checksum = "a829027bd95e54cfe13e3e258a1ae7b645960553fb82b75ff852c29688ee595b"
 dependencies = [
  "futures",
  "rustversion",
- "thiserror",
+ "thiserror 1.0.56",
 ]
 
 [[package]]
@@ -746,7 +505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.48",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -785,28 +544,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prokio"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b55e106e5791fa5a13abd13c85d6127312e8e09098059ca2bc9b03ca4cf488"
-dependencies = [
- "futures",
- "gloo 0.8.1",
- "num_cpus",
- "once_cell",
- "pin-project",
- "pinned",
- "tokio",
- "tokio-stream",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -823,12 +565,6 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustversion"
@@ -853,17 +589,6 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9b713f70513ae1f8d92665bbbbda5c295c2cf1da5542881ae5eefe20c9af132"
@@ -881,7 +606,7 @@ checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -929,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -942,7 +667,7 @@ dependencies = [
 name = "table-rs"
 version = "0.0.4"
 dependencies = [
- "gloo-timers 0.3.0",
+ "gloo-timers",
  "web-sys",
  "yew",
 ]
@@ -967,7 +692,16 @@ version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.56",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -978,17 +712,39 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "backtrace",
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1000,6 +756,23 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokise"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf97738ce15b9e9cc1671ea29b0f6c56538719e1a092d19cc2134bf144e40e"
+dependencies = [
+ "futures",
+ "gloo",
+ "num_cpus",
+ "once_cell",
+ "pin-project",
+ "pinned",
+ "tokio",
+ "tokio-stream",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1038,7 +811,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1096,7 +869,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -1131,7 +904,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.114",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1177,22 +950,22 @@ dependencies = [
 
 [[package]]
 name = "yew"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1a03f255c70c7aa3e9c62e15292f142ede0564123543c1cc0c7a4f31660cac"
+checksum = "3346273ed61b636f5d84e6c696d40f380045b5565b36c5c47f8fc634b8bf5be6"
 dependencies = [
  "console_error_panic_hook",
  "futures",
- "gloo 0.10.0",
+ "gloo",
  "implicit-clone",
  "indexmap",
  "js-sys",
- "prokio",
  "rustversion",
  "serde",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
+ "tokise",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1202,26 +975,26 @@ dependencies = [
 
 [[package]]
 name = "yew-macro"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fd8ca5166d69e59f796500a2ce432ff751edecbbb308ca59fd3fe4d0343de2"
+checksum = "479e94d645dde3749e81d488c1d32987509dd3b8c31650fcf6e3af1f370e913b"
 dependencies = [
- "boolinator",
  "once_cell",
  "prettyplease",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "rustversion",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "yew-router"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca1d5052c96e6762b4d6209a8aded597758d442e6c479995faf0c7b5538e0c6"
+checksum = "415cb628900ddf1eaf55ebd04163adf1ea80d3f5a9832a876554f9c0fdd4c282"
 dependencies = [
- "gloo 0.10.0",
+ "gloo",
  "js-sys",
  "route-recognizer",
  "serde",
@@ -1236,11 +1009,11 @@ dependencies = [
 
 [[package]]
 name = "yew-router-macro"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bfd190a07ca8cfde7cd4c52b3ac463803dc07323db8c34daa697e86365978c"
+checksum = "9e87a3ce33434ab66a700edbaf2cc8a417d9b89f00a6fd8216fd6ac83b0e7b1c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.114",
 ]

--- a/examples/yew/Cargo.lock
+++ b/examples/yew/Cargo.lock
@@ -956,6 +956,7 @@ dependencies = [
  "maplit",
  "table-rs",
  "wasm-logger",
+ "web-sys",
  "yew",
  "yew-router",
 ]

--- a/examples/yew/Cargo.toml
+++ b/examples/yew/Cargo.toml
@@ -14,6 +14,7 @@ wasm-logger = "0.2.0"
 yew = { version = "0.21.0", features = ["csr"], default-features = false }
 yew-router = { version = "0.18.0", default-features = false }
 maplit = "1.0.2"
+web-sys = { version = "0.3", features = ["Window"] }
 
 [profile.release]
 codegen-units = 1

--- a/examples/yew/Cargo.toml
+++ b/examples/yew/Cargo.toml
@@ -11,8 +11,8 @@ table-rs = { path = "../../", features = ["yew"] }
 console_error_panic_hook = "0.1.7"
 log = "0.4.22"
 wasm-logger = "0.2.0"
-yew = { version = "0.21.0", features = ["csr"], default-features = false }
-yew-router = { version = "0.18.0", default-features = false }
+yew = { version = "0.22.0", features = ["csr"], default-features = false }
+yew-router = { version = "0.19.0", default-features = false }
 maplit = "1.0.2"
 web-sys = { version = "0.3", features = ["Window"] }
 

--- a/examples/yew/src/pages/landing.rs
+++ b/examples/yew/src/pages/landing.rs
@@ -489,6 +489,54 @@ pub fn example13() -> Html {
     }
 }
 
+#[function_component(Example14)]
+pub fn example14() -> Html {
+    let data = vec![
+        hashmap! { "name" => "Ferris".to_string(), "email" => "ferris@opensass.org".to_string() },
+        hashmap! { "name" => "Ferros".to_string(), "email" => "ferros@opensass.org".to_string() },
+        hashmap! { "name" => "Crab".to_string(), "email" => "crab@opensass.org".to_string() },
+    ];
+
+    let columns = vec![
+        Column {
+            id: "name",
+            header: "Name",
+            sortable: true,
+            ..Default::default()
+        },
+        Column {
+            id: "email",
+            header: "Email",
+            sortable: true,
+            ..Default::default()
+        },
+    ];
+
+    let row_end_component = Callback::from(|row: std::collections::HashMap<&'static str, String>| {
+        let name = row.get("name").cloned().unwrap_or_default();
+        let onclick = Callback::from(move |_| {
+            let window = web_sys::window().unwrap();
+            window.alert_with_message(&format!("Action for {}!", name)).unwrap();
+        });
+        html! {
+            <button
+                class="px-2 py-1 text-xs text-white bg-green-500 rounded hover:bg-green-600"
+                {onclick}
+            >
+                { "Action" }
+            </button>
+        }
+    });
+
+    html! {
+        <Table
+            data={data}
+            columns={columns}
+            row_end_component={row_end_component}
+        />
+    }
+}
+
 #[function_component(LandingPage)]
 pub fn landing_page() -> Html {
     html! {
@@ -1091,6 +1139,55 @@ pub fn example13() -> Html {
 }"#
                 >
                     <Example13 />
+                </ExampleCard>
+                <ExampleCard
+                    title="Row End Component (Actions)"
+                    code=r#"use yew::prelude::*;
+use maplit::hashmap;
+use table_rs::yew::table::Table;
+use table_rs::yew::types::Column;
+
+#[function_component(Example14)]
+pub fn example14() -> Html {
+    let data = vec![
+        hashmap! { "name" => "Ferris".to_string(), "email" => "ferris@opensass.org".to_string() },
+        hashmap! { "name" => "Ferros".to_string(), "email" => "ferros@opensass.org".to_string() },
+        hashmap! { "name" => "Crab".to_string(), "email" => "crab@opensass.org".to_string() },
+    ];
+
+    let columns = vec![
+        Column { id: "name", header: "Name", sortable: true, ..Default::default() },
+        Column { id: "email", header: "Email", sortable: true, ..Default::default() },
+    ];
+
+    let row_end_component = Callback::from(|row: std::collections::HashMap<&'static str, String>| {
+        let name = row.get("name").cloned().unwrap_or_default();
+        let onclick = Callback::from(move |_| {
+            web_sys::window()
+                .unwrap()
+                .alert_with_message(&format!("Action for {}!", name))
+                .unwrap();
+        });
+        html! {
+            <button
+                class="px-2 py-1 text-xs text-white bg-green-500 rounded hover:bg-green-600"
+                {onclick}
+            >
+                { "Action" }
+            </button>
+        }
+    });
+
+    html! {
+        <Table
+            data={data}
+            columns={columns}
+            row_end_component={row_end_component}
+        />
+    }
+}"#
+                >
+                    <Example14 />
                 </ExampleCard>
             </div>
         </div>

--- a/examples/yew/src/pages/landing.rs
+++ b/examples/yew/src/pages/landing.rs
@@ -533,6 +533,7 @@ pub fn example14() -> Html {
             data={data}
             columns={columns}
             row_end_component={row_end_component}
+            default_sort_column={Some("Name")}
         />
     }
 }
@@ -1183,6 +1184,7 @@ pub fn example14() -> Html {
             data={data}
             columns={columns}
             row_end_component={row_end_component}
+            default_sort_column={"Name"}
         />
     }
 }"#

--- a/src/dioxus/body.rs
+++ b/src/dioxus/body.rs
@@ -65,6 +65,8 @@ pub fn TableBody(
     loading: bool,
     classes: TableClasses,
     texts: TableTexts,
+    #[props(default)]
+    row_end_component: Option<ReadOnlySignal<Callback<HashMap<&'static str, String>, Element>>>,
 ) -> Element {
     let content = if loading {
         rsx! {
@@ -91,6 +93,11 @@ pub fn TableBody(
                     for col in columns.iter() {
                         td { class: "{classes.body_cell}", role: "cell",
                             "{row.get(col.id).unwrap_or(&String::new())}"
+                        }
+                    }
+                    if let Some(component) = row_end_component {
+                        td { class: "{classes.body_cell}", role: "cell",
+                            {component.read().call(row.clone())}
                         }
                     }
                 }

--- a/src/dioxus/body.rs
+++ b/src/dioxus/body.rs
@@ -92,7 +92,11 @@ pub fn TableBody(
                 tr { class: "{classes.row}", role: "row",
                     for col in columns.iter() {
                         td { class: "{classes.body_cell}", role: "cell",
-                            "{row.get(col.id).unwrap_or(&String::new())}"
+                            if let Some(render) = &col.cell_render {
+                                {render.read().call(row.clone())}
+                            } else {
+                                "{row.get(col.id).unwrap_or(&String::new())}"
+                            }
                         }
                     }
                     if let Some(component) = row_end_component {

--- a/src/dioxus/header.rs
+++ b/src/dioxus/header.rs
@@ -62,6 +62,8 @@ pub fn TableHeader(
     sort_order: Signal<SortOrder>,
     on_sort_column: EventHandler<&'static str>,
     classes: TableClasses,
+    #[props(default)]
+    has_row_end: bool,
 ) -> Element {
     let header_cells = columns.iter().map(|col| {
         let col_id = col.id;
@@ -102,6 +104,9 @@ pub fn TableHeader(
         thead { class: "{classes.thead}",
             tr { class: "{classes.row}", role: "row",
                 {header_cells}
+                if has_row_end {
+                    th { class: "{classes.header_cell}", role: "columnheader" }
+                }
             }
         }
     }

--- a/src/dioxus/table.rs
+++ b/src/dioxus/table.rs
@@ -78,6 +78,7 @@ pub fn Table(props: TableProps) -> Element {
         search,
         texts,
         classes,
+        row_end_component,
     } = props;
 
     let mut page = use_signal(|| 0_usize);
@@ -194,6 +195,7 @@ pub fn Table(props: TableProps) -> Element {
                     sort_order: sort_order,
                     on_sort_column: on_sort_column,
                     classes: classes.clone(),
+                    has_row_end: row_end_component.is_some(),
                 }
                 TableBody {
                     columns: columns.clone(),
@@ -201,6 +203,7 @@ pub fn Table(props: TableProps) -> Element {
                     loading: loading,
                     classes: classes.clone(),
                     texts: texts.clone(),
+                    row_end_component: row_end_component.clone(),
                 }
             }
             {pagination_controls}

--- a/src/dioxus/types.rs
+++ b/src/dioxus/types.rs
@@ -161,6 +161,10 @@ pub struct TableProps {
     /// CSS classes for styling different parts of the table.
     #[props(default)]
     pub classes: TableClasses,
+
+    /// Optional component to render at the end of each row.
+    #[props(default)]
+    pub row_end_component: Option<ReadOnlySignal<Callback<HashMap<&'static str, String>, Element>>>,
 }
 
 /// Sort direction (ascending or descending).

--- a/src/dioxus/types.rs
+++ b/src/dioxus/types.rs
@@ -10,6 +10,10 @@ pub struct Column {
     /// Header text displayed in the column.
     pub header: &'static str,
 
+    /// Optional callback to render custom element for a cell.
+    #[props(default)]
+    pub cell_render: Option<ReadOnlySignal<Callback<HashMap<&'static str, String>, Element>>>,
+
     /// Whether this column is sortable.
     #[props(default)]
     pub sortable: bool,

--- a/src/yew/body.rs
+++ b/src/yew/body.rs
@@ -78,32 +78,23 @@ pub fn body(props: &TableBodyProps) -> Html {
                     }
                 } else {
                     html! {
-                        for rows.iter().map(|row| {
-                            html! {
-                                <tr class={classes.row} role="row">
-                                    {
-                                        for columns.iter().map(|col| {
-                                            html! {
-                                                <td class={classes.body_cell} role="cell">{ row.get(col.id).unwrap_or(&"".to_string()) }</td>
-                                            }
-                                        })
-                                    }
-                                    {
-                                        if let Some(component) = row_end_component {
-                                            html! {
-                                                <td class={classes.body_cell} role="cell">
-                                                    { component.emit(row.clone()) }
-                                                </td>
-                                            }
-                                        } else {
-                                            html! {}
-                                        }
-                                    }
-                                </tr>
-                            }
-                        })
+                        for row in rows {
+                            <tr class={classes.row} role="row">
+                                for col in columns {
+                                    <td class={classes.body_cell} role="cell">{ row.get(col.id).unwrap_or(&"".to_string()) }</td>
+                                }
+                                if let Some(component) = row_end_component {
+                                        <td class={classes.body_cell} role="cell">
+                                            { component.emit(row.clone()) }
+                                        </td>
+                                } else {
+                                    // html! {}
+                                }
+                            </tr>
+                        }
                     }
-                } }
+                }
+            }
         </tbody>
     }
 }

--- a/src/yew/body.rs
+++ b/src/yew/body.rs
@@ -63,6 +63,7 @@ pub fn body(props: &TableBodyProps) -> Html {
         loading,
         classes,
         texts,
+        row_end_component,
     } = props;
 
     html! {
@@ -86,6 +87,17 @@ pub fn body(props: &TableBodyProps) -> Html {
                                                 <td class={classes.body_cell} role="cell">{ row.get(col.id).unwrap_or(&"".to_string()) }</td>
                                             }
                                         })
+                                    }
+                                    {
+                                        if let Some(component) = row_end_component {
+                                            html! {
+                                                <td class={classes.body_cell} role="cell">
+                                                    { component.emit(row.clone()) }
+                                                </td>
+                                            }
+                                        } else {
+                                            html! {}
+                                        }
                                     }
                                 </tr>
                             }

--- a/src/yew/body.rs
+++ b/src/yew/body.rs
@@ -81,7 +81,15 @@ pub fn body(props: &TableBodyProps) -> Html {
                         for row in rows {
                             <tr class={classes.row} role="row">
                                 for col in columns {
-                                    <td class={classes.body_cell} role="cell">{ row.get(col.id).unwrap_or(&"".to_string()) }</td>
+                                    <td class={classes.body_cell} role="cell">
+                                        { 
+                                            if let Some(render) = &col.cell_render {
+                                                render.emit(row.clone())
+                                            } else {
+                                                html! { row.get(col.id).unwrap_or(&"".to_string()) }
+                                            }
+                                        }
+                                    </td>
                                 }
                                 if let Some(component) = row_end_component {
                                         <td class={classes.body_cell} role="cell">

--- a/src/yew/header.rs
+++ b/src/yew/header.rs
@@ -58,6 +58,7 @@ pub fn header(props: &TableHeaderProps) -> Html {
         sort_order,
         on_sort_column,
         classes,
+        has_row_end,
     } = props;
 
     html! {
@@ -91,6 +92,13 @@ pub fn header(props: &TableHeaderProps) -> Html {
                         </th>
                     }
                 }) }
+                { if *has_row_end {
+                    html! {
+                        <th class={classes.header_cell.clone()} role="columnheader"></th>
+                    }
+                } else {
+                    html! {}
+                } }
             </tr>
         </thead>
     }

--- a/src/yew/header.rs
+++ b/src/yew/header.rs
@@ -71,12 +71,17 @@ pub fn header(props: &TableHeaderProps) -> Html {
                         Some(Callback::from(move |_| on_sort_column.emit(col_id)))
                     } else { None };
 
+                    let header_style = format!(
+                        "position: sticky; top: 0; z-index: 1; background-color: var(--bs-body-bg, white); {}",
+                        col.style.unwrap_or_default()
+                    );
+
                     html! {
                         <th
                             {onclick}
                             role="columnheader"
                             class={format!("{} {}", classes.header_cell, col.class.unwrap_or("")).trim().to_string()}
-                            style={col.style.unwrap_or_default()}
+                            style={header_style}
                             aria-sort={
                                 if Some(col.id) == **sort_column {
                                     match **sort_order {
@@ -93,8 +98,9 @@ pub fn header(props: &TableHeaderProps) -> Html {
                     }
                 }) }
                 { if *has_row_end {
+                    let row_end_header_style = "position: sticky; top: 0; z-index: 1; background-color: var(--bs-body-bg, white);";
                     html! {
-                        <th class={classes.header_cell.clone()} role="columnheader"></th>
+                        <th class={classes.header_cell} role="columnheader" style={row_end_header_style}></th>
                     }
                 } else {
                     html! {}

--- a/src/yew/table.rs
+++ b/src/yew/table.rs
@@ -91,8 +91,8 @@ pub fn table(props: &TableProps) -> Html {
     } = props;
 
     let page = use_state(|| 0);
-    let sort_column = use_state(|| default_sort_column.clone());
-    let sort_order = use_state(|| default_sort_order.clone());
+    let sort_column = use_state(|| None::<&'static str>);
+    let sort_order = use_state(|| SortOrder::Asc);
     let search_query = use_state(|| {
         let window = web_sys::window().unwrap();
         let search_params =

--- a/src/yew/table.rs
+++ b/src/yew/table.rs
@@ -222,7 +222,7 @@ pub fn table(props: &TableProps) -> Html {
             </table>
             { if *paginate {
                     html! {
-                        <PaginationControls {page} {total_pages} />
+                        <PaginationControls {page} {total_pages} classes={classes.clone()}/>
                     }
                 } else {
                     html! {}

--- a/src/yew/table.rs
+++ b/src/yew/table.rs
@@ -86,11 +86,13 @@ pub fn table(props: &TableProps) -> Html {
         search,
         texts,
         row_end_component,
+        default_sort_column,
+        default_sort_order,
     } = props;
 
     let page = use_state(|| 0);
-    let sort_column = use_state(|| None::<&'static str>);
-    let sort_order = use_state(|| SortOrder::Asc);
+    let sort_column = use_state(|| *default_sort_column);
+    let sort_order = use_state(|| *default_sort_order);
     let search_query = use_state(|| {
         let window = web_sys::window().unwrap();
         let search_params =

--- a/src/yew/table.rs
+++ b/src/yew/table.rs
@@ -192,8 +192,17 @@ pub fn table(props: &TableProps) -> Html {
         })
     };
 
+    let container_style = format!(
+        "display: flex; flex-direction: column; height: 100%; {}",
+        styles.get("container").unwrap_or(&"")
+    );
+    let table_style = format!(
+        "flex: 1 1 auto; min-height: 0; {}",
+        styles.get("table").unwrap_or(&"")
+    );
+
     html! {
-        <div class={classes.container}>
+        <div class={classes.container} style={container_style}>
             { if *search {
                     html! {
                         <input
@@ -208,7 +217,7 @@ pub fn table(props: &TableProps) -> Html {
                 } else {
                     html! {}
                 } }
-            <table class={classes.table} style={*styles.get("table").unwrap_or(&"")} role="table">
+            <table class={classes.table} style={table_style} role="table">
                 <TableHeader
                     columns={columns.clone()}
                     {sort_column}
@@ -228,7 +237,9 @@ pub fn table(props: &TableProps) -> Html {
             </table>
             { if *paginate {
                     html! {
-                        <PaginationControls {page} {total_pages} classes={classes.clone()} texts={texts.clone()}/>
+                        <div style="margin-top: auto;">
+                            <PaginationControls {page} {total_pages} classes={classes.clone()} texts={texts.clone()}/>
+                        </div>
                     }
                 } else {
                     html! {}

--- a/src/yew/table.rs
+++ b/src/yew/table.rs
@@ -91,8 +91,8 @@ pub fn table(props: &TableProps) -> Html {
     } = props;
 
     let page = use_state(|| 0);
-    let sort_column = use_state(|| None::<&'static str>);
-    let sort_order = use_state(|| SortOrder::Asc);
+    let sort_column = use_state(|| default_sort_column.clone());
+    let sort_order = use_state(|| default_sort_order.clone());
     let search_query = use_state(|| {
         let window = web_sys::window().unwrap();
         let search_params =
@@ -193,12 +193,22 @@ pub fn table(props: &TableProps) -> Html {
     };
 
     let container_style = format!(
-        "display: flex; flex-direction: column; height: 100%; {}",
+        "display: flex; flex-direction: column; height: 100%; overflow: auto; {}",
         styles.get("container").unwrap_or(&"")
     );
     let table_style = format!(
-        "flex: 1 1 auto; min-height: 0; {}",
+        "flex: 1 1 auto; min-height: 0; border-collapse: separate; border-spacing: 0; {}",
         styles.get("table").unwrap_or(&"")
+    );
+
+    let search_style = format!(
+        "position: sticky; top: 0; z-index: 2; background-color: var(--bs-body-bg, white); {}",
+        styles.get("search").unwrap_or(&"")
+    );
+
+    let pagination_style = format!(
+        "margin-top: auto; position: sticky; bottom: 0; z-index: 2; background-color: var(--bs-body-bg, white); {}",
+        styles.get("pagination").unwrap_or(&"")
     );
 
     html! {
@@ -207,6 +217,7 @@ pub fn table(props: &TableProps) -> Html {
                     html! {
                         <input
                             class={classes.search_input}
+                            style={search_style}
                             type="text"
                             value={(*search_query).clone()}
                             placeholder={texts.search_placeholder}
@@ -237,7 +248,7 @@ pub fn table(props: &TableProps) -> Html {
             </table>
             { if *paginate {
                     html! {
-                        <div style="margin-top: auto;">
+                        <div style={pagination_style}>
                             <PaginationControls {page} {total_pages} classes={classes.clone()} texts={texts.clone()}/>
                         </div>
                     }

--- a/src/yew/table.rs
+++ b/src/yew/table.rs
@@ -91,8 +91,8 @@ pub fn table(props: &TableProps) -> Html {
     } = props;
 
     let page = use_state(|| 0);
-    let sort_column = use_state(|| *default_sort_column);
-    let sort_order = use_state(|| *default_sort_order);
+    let sort_column = use_state(|| default_sort_column.clone());
+    let sort_order = use_state(|| default_sort_order.clone());
     let search_query = use_state(|| {
         let window = web_sys::window().unwrap();
         let search_params =

--- a/src/yew/table.rs
+++ b/src/yew/table.rs
@@ -85,6 +85,7 @@ pub fn table(props: &TableProps) -> Html {
         paginate,
         search,
         texts,
+        row_end_component,
     } = props;
 
     let page = use_state(|| 0);
@@ -212,17 +213,20 @@ pub fn table(props: &TableProps) -> Html {
                     {sort_order}
                     {on_sort_column}
                     classes={classes.clone()}
+                    has_row_end={row_end_component.is_some()}
                 />
                 <TableBody
                     columns={columns.clone()}
                     rows={page_rows.to_vec()}
                     loading={loading}
                     classes={classes.clone()}
+                    texts={texts.clone()}
+                    row_end_component={row_end_component.clone()}
                 />
             </table>
             { if *paginate {
                     html! {
-                        <PaginationControls {page} {total_pages} classes={classes.clone()}/>
+                        <PaginationControls {page} {total_pages} classes={classes.clone()} texts={texts.clone()}/>
                     }
                 } else {
                     html! {}

--- a/src/yew/types.rs
+++ b/src/yew/types.rs
@@ -198,6 +198,14 @@ pub struct TableProps {
     /// Optional component to render at the end of each row.
     #[prop_or_default]
     pub row_end_component: Option<Callback<HashMap<&'static str, String>, Html>>,
+
+    /// Default sort column identifier.
+    #[prop_or(None)]
+    pub default_sort_column: Option<&'static str>,
+
+    /// Default sort order.
+    #[prop_or(SortOrder::Asc)]
+    pub default_sort_order: SortOrder
 }
 
 /// Props for the table header including sorting logic.

--- a/src/yew/types.rs
+++ b/src/yew/types.rs
@@ -194,6 +194,10 @@ pub struct TableProps {
     /// Text labels for the table UI.
     #[prop_or_default]
     pub texts: TableTexts,
+
+    /// Optional component to render at the end of each row.
+    #[prop_or_default]
+    pub row_end_component: Option<Callback<HashMap<&'static str, String>, Html>>,
 }
 
 /// Props for the table header including sorting logic.
@@ -238,6 +242,10 @@ pub struct TableHeaderProps {
     /// CSS classes used to style the table header.
     #[prop_or_default]
     pub classes: TableClasses,
+
+    /// Whether there is a row end component that needs an extra header cell.
+    #[prop_or(false)]
+    pub has_row_end: bool,
 }
 
 /// Props for the pagination controls component.
@@ -281,4 +289,8 @@ pub struct TableBodyProps {
     /// Text labels used in the body (e.g., loading, empty).
     #[prop_or_default]
     pub texts: TableTexts,
+
+    /// Optional component to render at the end of each row.
+    #[prop_or_default]
+    pub row_end_component: Option<Callback<HashMap<&'static str, String>, Html>>,
 }

--- a/src/yew/types.rs
+++ b/src/yew/types.rs
@@ -12,9 +12,9 @@ pub struct Column {
     #[prop_or("")]
     pub header: &'static str,
 
-    /// Callback triggered when accessing column data; can be used for custom rendering.
-    #[prop_or(Callback::noop())]
-    pub accessor: Callback<()>,
+    /// Optional callback to render custom HTML for a cell.
+    #[prop_or_default]
+    pub cell_render: Option<Callback<HashMap<&'static str, String>, Html>>,
 
     /// Determines if the column is sortable.
     #[prop_or(false)]


### PR DESCRIPTION
Currently, the pagination controls aren't passed the TableClasses object by the parent table component, leading it to look a bit drab. I've passed along the TableClasses and TableTexts objects into the component.

In addition, a common pattern for tables is the ability to modify the record; I have added an "end_row_component"
and an example of its usage to the yew examples:

<img width="599" height="877" alt="image" src="https://github.com/user-attachments/assets/670a02cf-df02-4976-8ab3-4695b7f7167a" />

This partially addresses https://github.com/opensass/table-rs/issues/7